### PR TITLE
Add glomap option for colmap mapper

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -83,6 +83,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """
     colmap_cmd: str = "colmap"
     """How to call the COLMAP executable."""
+    mapper: Literal["colmap", "glomap"] = "colmap"
+    """Binary to use for the mapping stage. Either ``colmap`` or ``glomap``."""
     images_per_equirect: Literal[8, 14] = 8
     """Number of samples per image to take from each equirectangular image.
        Used only when camera-type is equirectangular.
@@ -219,6 +221,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 matching_method=self.matching_method,
                 refine_intrinsics=self.refine_intrinsics,
                 colmap_cmd=self.colmap_cmd,
+                mapper=self.mapper,
             )
         elif sfm_tool == "hloc":
             if mask_path is not None:
@@ -245,6 +248,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
         super().__post_init__()
         install_checks.check_ffmpeg_installed()
         install_checks.check_colmap_installed(self.colmap_cmd)
+        if self.mapper == "glomap":
+            install_checks.check_colmap_installed("glomap")
 
         if self.crop_bottom < 0.0 or self.crop_bottom > 1:
             raise RuntimeError("crop_bottom must be set between 0 and 1.")

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -99,6 +99,7 @@ def run_colmap(
     matching_method: Literal["vocab_tree", "exhaustive", "sequential"] = "vocab_tree",
     refine_intrinsics: bool = True,
     colmap_cmd: str = "colmap",
+    mapper: Literal["colmap", "glomap"] = "colmap",
 ) -> None:
     """Runs COLMAP on the images.
 
@@ -111,7 +112,8 @@ def run_colmap(
         verbose: If True, logs the output of the command.
         matching_method: Matching method to use.
         refine_intrinsics: If True, refine intrinsics.
-        colmap_cmd: Path to the COLMAP executable.
+        colmap_cmd: Path to the COLMAP executable for feature extraction and matching.
+        mapper: Binary to use for the mapping stage ("colmap" or "glomap").
     """
 
     colmap_version = get_colmap_version(colmap_cmd)
@@ -154,7 +156,7 @@ def run_colmap(
     sparse_dir = colmap_dir / "sparse"
     sparse_dir.mkdir(parents=True, exist_ok=True)
     mapper_cmd = [
-        f"{colmap_cmd} mapper",
+        f"{mapper} mapper",
         f"--database_path {colmap_dir / 'database.db'}",
         f"--image_path {image_dir}",
         f"--output_path {sparse_dir}",


### PR DESCRIPTION
## Summary
- add `mapper` flag to choose between `colmap` and `glomap`
- propagate mapper choice to the COLMAP run utility

## Testing
- `ruff check nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py nerfstudio/process_data/colmap_utils.py`
- `ruff format --check nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py nerfstudio/process_data/colmap_utils.py`
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_6841397f7990832c80684c85b8d44035