### PR TITLE
Fix colmap mapper tolerance option

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -167,8 +167,8 @@ def run_colmap(
         f"--image_path {image_dir}",
         f"--output_path {sparse_dir}",
     ]
-    if colmap_version >= Version("3.7"):
-        mapper_cmd.append("--Mapper.ba_global_function_tolerance=1e-6")
+    if colmap_version >= Version("3.7") and mapper == "colmap":
+        mapper_cmd.append("--Mapper.ba_global_function_tolerance 1e-6")
 
     mapper_cmd = " ".join(mapper_cmd)
 


### PR DESCRIPTION
## Summary
- pass `--Mapper.ba_global_function_tolerance` only when using the colmap mapper

## Testing
- `pytest -q` *(fails: unrecognized arguments -n=4 --jaxtyping-packages=nerfstudio)*

------
https://chatgpt.com/codex/tasks/task_b_6841638cd758832ca2e44ec70f2e0eea