### PR TITLE
Add affine SIFT options to COLMAP

### DIFF
--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -42,6 +42,7 @@ To assist running on custom data we have a script that will process a video or f
 ```bash
 ns-process-data {images, video} --data {DATA_PATH} --output-dir {PROCESSED_DATA_DIR}
 ```
+Advanced SIFT feature extraction options such as `--estimate-affine-shape` and `--domain-size-pooling` can also be passed to `ns-process-data` if desired.
 
 ### Training on your data
 

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -106,6 +106,10 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     use_single_camera_mode: bool = True
     """Whether to assume all images taken with the same camera characteristics, set to False for multiple cameras in colmap (only works with hloc sfm_tool).
     """
+    estimate_affine_shape: bool = False
+    """If True, enable affine shape estimation during SIFT feature extraction."""
+    domain_size_pooling: bool = False
+    """If True, enable domain size pooling during SIFT feature extraction."""
 
     @staticmethod
     def default_colmap_path() -> Path:
@@ -222,6 +226,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 refine_intrinsics=self.refine_intrinsics,
                 colmap_cmd=self.colmap_cmd,
                 mapper=self.mapper,
+                estimate_affine_shape=self.estimate_affine_shape,
+                domain_size_pooling=self.domain_size_pooling,
             )
         elif sfm_tool == "hloc":
             if mask_path is not None:

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -100,6 +100,8 @@ def run_colmap(
     refine_intrinsics: bool = True,
     colmap_cmd: str = "colmap",
     mapper: Literal["colmap", "glomap"] = "colmap",
+    estimate_affine_shape: bool = False,
+    domain_size_pooling: bool = False,
 ) -> None:
     """Runs COLMAP on the images.
 
@@ -114,6 +116,8 @@ def run_colmap(
         refine_intrinsics: If True, refine intrinsics.
         colmap_cmd: Path to the COLMAP executable for feature extraction and matching.
         mapper: Binary to use for the mapping stage ("colmap" or "glomap").
+        estimate_affine_shape: If True, enable affine shape estimation for SIFT.
+        domain_size_pooling: If True, enable domain size pooling for SIFT.
     """
 
     colmap_version = get_colmap_version(colmap_cmd)
@@ -129,6 +133,8 @@ def run_colmap(
         "--ImageReader.single_camera 1",
         f"--ImageReader.camera_model {camera_model.value}",
         f"--SiftExtraction.use_gpu {int(gpu)}",
+        f"--SiftExtraction.estimate_affine_shape {int(estimate_affine_shape)}",
+        f"--SiftExtraction.domain_size_pooling {int(domain_size_pooling)}",
     ]
     if camera_mask_path is not None:
         feature_extractor_cmd.append(f"--ImageReader.camera_mask_path {camera_mask_path}")

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -521,7 +521,7 @@ class NotInstalled:
     def main(self) -> None: ...
 
 
-Commands = Union[
+CommandsType = Union[
     Annotated[ImagesToNerfstudioDataset, tyro.conf.subcommand(name="images")],
     Annotated[VideoToNerfstudioDataset, tyro.conf.subcommand(name="video")],
     Annotated[ProcessPolycam, tyro.conf.subcommand(name="polycam")],
@@ -541,10 +541,11 @@ if projectaria_tools is not None:
     from nerfstudio.scripts.datasets.process_project_aria import ProcessProjectAria
 
     # Note that Union[A, Union[B, C]] == Union[A, B, C].
-    Commands = Union[Commands, Annotated[ProcessProjectAria, tyro.conf.subcommand(name="aria")]]
+    CommandsType = Union[CommandsType, Annotated[ProcessProjectAria, tyro.conf.subcommand(name="aria")]]
 else:
-    Commands = Union[
-        Commands,
+
+    CommandsType = Union[
+        CommandsType,
         Annotated[
             NotInstalled,
             tyro.conf.subcommand(
@@ -553,6 +554,8 @@ else:
             ),
         ],
     ]
+
+Commands = tyro.conf.FlagConversionOff[CommandsType]
 
 
 def entrypoint():


### PR DESCRIPTION
## Summary
- support `estimate_affine_shape` and `domain_size_pooling` options when running COLMAP
- expose options through the `ns-process-data` CLI via tyro `FlagConversionOff`
- document these flags in the custom dataset guide

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_b_68415da63f30832caa046ee160add430